### PR TITLE
deps: upgrade snarkvm to v4.8.1 (rehearsal)

### DIFF
--- a/sdk-abi/Cargo.lock
+++ b/sdk-abi/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aleo-abi"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "leo-abi",
@@ -1377,7 +1377,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "leo-abi"
 version = "4.3.2"
-source = "git+https://github.com/ProvableHQ/leo?rev=ba2c01722a48f84b4d90b93aeaf8305b7c03dbce#ba2c01722a48f84b4d90b93aeaf8305b7c03dbce"
+source = "git+https://github.com/ProvableHQ/leo?rev=60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7#60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7"
 dependencies = [
  "indexmap",
  "itertools",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "leo-abi-types"
 version = "4.3.2"
-source = "git+https://github.com/ProvableHQ/leo?rev=ba2c01722a48f84b4d90b93aeaf8305b7c03dbce#ba2c01722a48f84b4d90b93aeaf8305b7c03dbce"
+source = "git+https://github.com/ProvableHQ/leo?rev=60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7#60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7"
 dependencies = [
  "serde",
 ]
@@ -1398,9 +1398,10 @@ dependencies = [
 [[package]]
 name = "leo-ast"
 version = "4.3.2"
-source = "git+https://github.com/ProvableHQ/leo?rev=ba2c01722a48f84b4d90b93aeaf8305b7c03dbce#ba2c01722a48f84b4d90b93aeaf8305b7c03dbce"
+source = "git+https://github.com/ProvableHQ/leo?rev=60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7#60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7"
 dependencies = [
  "anyhow",
+ "fxhash",
  "getrandom 0.4.3",
  "indexmap",
  "itertools",
@@ -1416,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "leo-disassembler"
 version = "4.3.2"
-source = "git+https://github.com/ProvableHQ/leo?rev=ba2c01722a48f84b4d90b93aeaf8305b7c03dbce#ba2c01722a48f84b4d90b93aeaf8305b7c03dbce"
+source = "git+https://github.com/ProvableHQ/leo?rev=60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7#60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7"
 dependencies = [
  "getrandom 0.4.3",
  "leo-ast",
@@ -1430,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "leo-errors"
 version = "4.3.2"
-source = "git+https://github.com/ProvableHQ/leo?rev=ba2c01722a48f84b4d90b93aeaf8305b7c03dbce#ba2c01722a48f84b4d90b93aeaf8305b7c03dbce"
+source = "git+https://github.com/ProvableHQ/leo?rev=60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7#60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1447,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "leo-span"
 version = "4.3.2"
-source = "git+https://github.com/ProvableHQ/leo?rev=ba2c01722a48f84b4d90b93aeaf8305b7c03dbce#ba2c01722a48f84b4d90b93aeaf8305b7c03dbce"
+source = "git+https://github.com/ProvableHQ/leo?rev=60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7#60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7"
 dependencies = [
  "ariadne",
  "fxhash",
@@ -2443,7 +2444,8 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.8.1"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e35ef2036e93bbfa2342f8c53c134f84d00f4e6cf008c577c88c88f95acdeb9"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -2462,8 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9324633a2ca8e6c1796d7d8d5a65f21aa03545acc7552db05d5b54ae6895093d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2489,8 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3100c3d4a0950ccbfdee58640e3da7e6ea421883f26d89e684ce2acd0a8a8b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2503,8 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ece1b5d533eb975a4971b1cd113583db4b1503f706f5c000dd4aa29d6adb07"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2513,8 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9ffedabd1d2a20ef1c776174235a460ba5eb92a38ee2ece59b565045371829"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2523,8 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3060cfc0d863fd1d3244b2c722864b5b54b36c1b252c27f285d6e20bdb6147"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2533,8 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4c7ab151b346df065a7e7eed58ae88f34d81bcd2443957140056a83215d41b"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2553,13 +2561,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58e027011380f20228c56366d578f0a1a768dd93a4199c54676f55b4486101a"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8f8b926e687ad79726fc5f100fd94296eb409473aed122d3defae3ff8d4d31"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2569,8 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89218041e04e1fbca9b0dc26cb1124cc03d3c3fe02b83fe578ff9effb3fb59fb"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2583,8 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e31ebf0f2725c9e04a279ae9093858aa2b20eb6c287d3b653d584b638f5540"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2598,8 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee5cbebc2b4eb00b690699167cf70ef0dc74da8509c9c0b93368b26d03bcba5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2611,8 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf2299aafd7df0695a8a9816d689bbae134227bc5a4d30f9f2f33234d706427"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2620,8 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2122f8eaa4eff3dd62d9fffebcb2f455e157d264b45dca12c4be537acb7d5b7c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2630,8 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a5e1863624072d61d6a3cc3c1bae47839ff819439f132e574b866a5de9d98"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2642,8 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1fc42313949a3895a5ab91b4ebb5ff02b11bceb41235f82b37c84f8c0ad763"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2654,8 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fb89773ab0afed9ef9042c10c52d6f0b7589bb57e11444135d12d53026617"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2665,8 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3f0b44d842e53af04afceff1629b5945be0e281c92ddb5e72c7ae0c49c3b14"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2677,8 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34c436414e7c2de53f18704a841af7c818101cd87337fd25a4c8bf69b13e741"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2690,8 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15550d188aa870e051b6a40d6868eb01d9367546fbc1c7878c195b4ab8a680e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2701,8 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25f8b9b2b39d0a9a94afb2e711cb7540f7b58483ebea10a42610582604bad44"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2717,8 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa3af2a6ea79048d641561b8fa1522ea2658f7f2e8c0cf2c94a7f126529b786"
 dependencies = [
  "aleo-std",
  "parking_lot",
@@ -2730,8 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c4ae1a3511bd3fc8eda645c4090f48b4242bc40f5accc67cf1da5c26393fef"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2750,8 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abb04b58b02f1ae1fe308bc89cf8521023bc5836bf00de43dcf927672dc29d5"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2768,8 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7a3b00538fd345023f76216b95a40e09521ac30c23eab5e10fccc8bffdbc6c"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2789,8 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffef5883feaf28a35cc3576952b13553e4b32817067c44ca458459650929d09d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2804,8 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc8bb7d753d9cb569ee0c451793d1aa3150055fd04b19d2f1afd2ed0d9eb025"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2815,16 +2843,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fb594e3b6260d237b41b160d5522a5d7e8faf845066db906c7340779c4d850"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3e36c42202308bbf81a605670e3417f4c04817954026c6f3de273e091cebac"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2833,8 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d042f829548154d28bef6af8dd00bbb731cc350c72a133db52ab7e0365687f3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2844,8 +2875,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bfc35c8b39c6688edcbeed60172e43a6a07e6676b06343901b5e306e7579e07"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2855,8 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704c2654e977afdc9682e2a4967f6cd7ee24019cb80744cc80c0e6df70508265"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2866,8 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c846bbc6076b0ce20e8fb1198a04743ef342a7d57e1845d142627abef396702b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2877,8 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884289cd786abe0e31e97fcf9c4dbc6cc988cd47da8ec3854e4f061af1f1e325"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2890,8 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c322a2c9b7222e7d0fed1559a5a5104b272b364eebec31499b1b3aba00c95c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2907,8 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b77772aded094332fab5fe488bc0280f2f94e78aeea2b87fcf2be0cb49444ed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2937,8 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb5d31f0e2a414aa8c2f40e4d80ebacde351adda4171b7dcd68b0cbe8ca10b0"
 dependencies = [
  "anyhow",
  "rand",
@@ -2949,8 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108da50438afee00396cb2c48419662ec2da8e771ec3a9f1a5b1ae794be98725"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2973,8 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b77dbf03fcfd0fa38bed6bc0cb9816fbb51d343db23346e56462c6c43c3e0083"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2985,8 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f82a9d27b7bad806115fa1dddaf043c1e168d8d4bc54fead73f98a472b4419"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -2998,8 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da425de42fdf84271ac1268d68ddd8d4f6bfc46b2804d754d8aee7fea46938cf"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3011,8 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f15ab0b561a2a882c95cd961f7fdaf4370cbf8d0590a726a9e6cf8c4ba8b4f5"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3023,8 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15656c4a89d7ab71d1883ad16e62148c82b30f335af8a25146ad3a6db4d5703"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3034,8 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4200e2f5f7a4312673123650a508148977e3d3695e49df84cc7a8420c428f5be"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3049,8 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133fa30f6a0c37cb027361b7630216f501bee08fd7a616b5a431afebaa52f798"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3062,8 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721fe467857f3f85aed85958a72fd3ddf333c1aa60bc8fca2c0770e1915682c6"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3071,8 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df3fdd09d494e649609f066155792e81ce57c218af0d250c3af963e878bdf2e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3091,8 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75d413a7b9eeecd59bfbfe088fa9177cdc0aea2004e66be4acd7d66314d3af91"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3113,8 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83e392b4439236341c4a376246fa4cf5fb8ca368f69f09aceab04dfa515f7f8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3130,8 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f780376da38c5efbdcf137a05d96d3cf492b87d30f3d8a5c7eecf8c48273273b"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3155,8 +3206,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6560dfd95e2963b86baae31222609cb7e5fcc734dbfbf5993559c56a6c6fa51"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3180,8 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "800fd59b4942e3ad2d06982f8f531a80706ca0fdd72f92a1e255cf47747dac20"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3215,8 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-error"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052014a8b414daaf1c4ba5582e9ddf8505b2c28ea8c09affd7c4b75a3bbfdcda"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -3227,8 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e0212359bcc226fa24019d24be728e414b00d5846218129adcb8d4ff74ae78"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3253,8 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14344567bdaac5d8aaa82e1e1fc458e448ec53f59b62d7c6808bfe60e39981c0"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -3274,8 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71052ce457f0ec7fefae8d3fb07b21a0cc3007c0956f6cd2a3b247113c393dc3"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3287,8 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1c9ddbc365e6575e3991bf191d8c0c42d9e55ba3963e7819ef047d77462e25"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3310,8 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a757dd7c952d69e6385cd0621c5c8ee7d4ab874f3ddc34b62a8d6bbfc56ae9ce"
 dependencies = [
  "proc-macro2",
  "quote 1.0.46",

--- a/sdk-abi/Cargo.toml
+++ b/sdk-abi/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "aleo-abi"
-version = "0.2.2"
+version = "0.3.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 description = "Python bindings for ABI generation from Aleo bytecode (via Leo's leo-abi crate)"
@@ -18,13 +18,13 @@ crate-type = ["cdylib"]
 anyhow = "1"
 pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py37", "anyhow"] }
 serde_json = "1"
-leo-abi = { git = "https://github.com/ProvableHQ/leo", rev = "ba2c01722a48f84b4d90b93aeaf8305b7c03dbce", package = "leo-abi", features = ["aleo-bytecode"] }
-leo-ast = { git = "https://github.com/ProvableHQ/leo", rev = "ba2c01722a48f84b4d90b93aeaf8305b7c03dbce", package = "leo-ast" }
-leo-disassembler = { git = "https://github.com/ProvableHQ/leo", rev = "ba2c01722a48f84b4d90b93aeaf8305b7c03dbce", package = "leo-disassembler" }
-leo-span = { git = "https://github.com/ProvableHQ/leo", rev = "ba2c01722a48f84b4d90b93aeaf8305b7c03dbce", package = "leo-span" }
+leo-abi = { git = "https://github.com/ProvableHQ/leo", rev = "60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7", package = "leo-abi", features = ["aleo-bytecode"] }
+leo-ast = { git = "https://github.com/ProvableHQ/leo", rev = "60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7", package = "leo-ast" }
+leo-disassembler = { git = "https://github.com/ProvableHQ/leo", rev = "60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7", package = "leo-disassembler" }
+leo-span = { git = "https://github.com/ProvableHQ/leo", rev = "60d258d3f2f0d8cae970fb4e4f6e3c0dd0d0b9c7", package = "leo-span" }
 # Same tag + feature set leo pins, so `Process<N>`/`Program<N>` are the same
 # types leo-disassembler's signatures expect.
-snarkvm = { git = "https://github.com/ProvableHQ/snarkVM", tag = "v4.8.0", features = ["test_consensus_heights", "dev_skip_checks", "test_targets", "history"] }
+snarkvm = { version = "4.8.1", features = ["test_consensus_heights", "dev_skip_checks", "test_targets", "history"] }
 
 [profile.release]
 opt-level = 3

--- a/sdk-abi/Cargo.toml
+++ b/sdk-abi/Cargo.toml
@@ -24,7 +24,7 @@ leo-disassembler = { git = "https://github.com/ProvableHQ/leo", rev = "ba2c01722
 leo-span = { git = "https://github.com/ProvableHQ/leo", rev = "ba2c01722a48f84b4d90b93aeaf8305b7c03dbce", package = "leo-span" }
 # Same tag + feature set leo pins, so `Process<N>`/`Program<N>` are the same
 # types leo-disassembler's signatures expect.
-snarkvm = { git = "https://github.com/ProvableHQ/snarkVM", tag = "v4.8.1", features = ["test_consensus_heights", "dev_skip_checks", "test_targets", "history"] }
+snarkvm = { git = "https://github.com/ProvableHQ/snarkVM", tag = "v4.8.0", features = ["test_consensus_heights", "dev_skip_checks", "test_targets", "history"] }
 
 [profile.release]
 opt-level = 3

--- a/sdk-abi/pyproject.toml
+++ b/sdk-abi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "aleo-contract-abi-generator"
-version = "0.2.2"
+version = "0.3.1"
 description = "Python bindings for ABI generation from Aleo bytecode"
 readme = "README.md"
 license = {text = "GPL-3.0-or-later"}

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -2310,8 +2310,8 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "4.8.1"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.7.3"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "anyhow",
  "rand",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2355,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2379,7 +2379,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2419,12 +2419,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2435,7 +2435,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2449,7 +2449,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2486,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2496,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2531,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "parking_lot",
@@ -2596,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2634,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2670,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2681,7 +2681,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -2689,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2732,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2743,7 +2743,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2756,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2773,7 +2773,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2803,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "anyhow",
  "rand",
@@ -2815,7 +2815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2839,7 +2839,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2851,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2900,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2928,7 +2928,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2957,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2979,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2996,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3078,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -3090,7 +3090,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3116,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -3137,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3150,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3173,7 +3173,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.46",

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aleo"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -2310,8 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e35ef2036e93bbfa2342f8c53c134f84d00f4e6cf008c577c88c88f95acdeb9"
 dependencies = [
  "anyhow",
  "rand",
@@ -2327,8 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9324633a2ca8e6c1796d7d8d5a65f21aa03545acc7552db05d5b54ae6895093d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2354,8 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3100c3d4a0950ccbfdee58640e3da7e6ea421883f26d89e684ce2acd0a8a8b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2368,8 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ece1b5d533eb975a4971b1cd113583db4b1503f706f5c000dd4aa29d6adb07"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -2378,8 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9ffedabd1d2a20ef1c776174235a460ba5eb92a38ee2ece59b565045371829"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2388,8 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3060cfc0d863fd1d3244b2c722864b5b54b36c1b252c27f285d6e20bdb6147"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2398,8 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4c7ab151b346df065a7e7eed58ae88f34d81bcd2443957140056a83215d41b"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2418,13 +2425,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58e027011380f20228c56366d578f0a1a768dd93a4199c54676f55b4486101a"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8f8b926e687ad79726fc5f100fd94296eb409473aed122d3defae3ff8d4d31"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -2434,8 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89218041e04e1fbca9b0dc26cb1124cc03d3c3fe02b83fe578ff9effb3fb59fb"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2448,8 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e31ebf0f2725c9e04a279ae9093858aa2b20eb6c287d3b653d584b638f5540"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -2463,8 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee5cbebc2b4eb00b690699167cf70ef0dc74da8509c9c0b93368b26d03bcba5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2476,8 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf2299aafd7df0695a8a9816d689bbae134227bc5a4d30f9f2f33234d706427"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -2485,8 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2122f8eaa4eff3dd62d9fffebcb2f455e157d264b45dca12c4be537acb7d5b7c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2495,8 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a5e1863624072d61d6a3cc3c1bae47839ff819439f132e574b866a5de9d98"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2507,8 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1fc42313949a3895a5ab91b4ebb5ff02b11bceb41235f82b37c84f8c0ad763"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2519,8 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fb89773ab0afed9ef9042c10c52d6f0b7589bb57e11444135d12d53026617"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2530,8 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3f0b44d842e53af04afceff1629b5945be0e281c92ddb5e72c7ae0c49c3b14"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -2542,8 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34c436414e7c2de53f18704a841af7c818101cd87337fd25a4c8bf69b13e741"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -2555,8 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15550d188aa870e051b6a40d6868eb01d9367546fbc1c7878c195b4ab8a680e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -2566,8 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25f8b9b2b39d0a9a94afb2e711cb7540f7b58483ebea10a42610582604bad44"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -2582,8 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa3af2a6ea79048d641561b8fa1522ea2658f7f2e8c0cf2c94a7f126529b786"
 dependencies = [
  "aleo-std",
  "parking_lot",
@@ -2595,8 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c4ae1a3511bd3fc8eda645c4090f48b4242bc40f5accc67cf1da5c26393fef"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -2615,8 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abb04b58b02f1ae1fe308bc89cf8521023bc5836bf00de43dcf927672dc29d5"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2633,8 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7a3b00538fd345023f76216b95a40e09521ac30c23eab5e10fccc8bffdbc6c"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -2654,8 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffef5883feaf28a35cc3576952b13553e4b32817067c44ca458459650929d09d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -2669,8 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc8bb7d753d9cb569ee0c451793d1aa3150055fd04b19d2f1afd2ed0d9eb025"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2680,16 +2707,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fb594e3b6260d237b41b160d5522a5d7e8faf845066db906c7340779c4d850"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3e36c42202308bbf81a605670e3417f4c04817954026c6f3de273e091cebac"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2698,8 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d042f829548154d28bef6af8dd00bbb731cc350c72a133db52ab7e0365687f3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2709,8 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bfc35c8b39c6688edcbeed60172e43a6a07e6676b06343901b5e306e7579e07"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2720,8 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704c2654e977afdc9682e2a4967f6cd7ee24019cb80744cc80c0e6df70508265"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2731,8 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c846bbc6076b0ce20e8fb1198a04743ef342a7d57e1845d142627abef396702b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -2742,8 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884289cd786abe0e31e97fcf9c4dbc6cc988cd47da8ec3854e4f061af1f1e325"
 dependencies = [
  "rand",
  "rustc_version",
@@ -2755,8 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c322a2c9b7222e7d0fed1559a5a5104b272b364eebec31499b1b3aba00c95c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2772,8 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b77772aded094332fab5fe488bc0280f2f94e78aeea2b87fcf2be0cb49444ed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2802,8 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb5d31f0e2a414aa8c2f40e4d80ebacde351adda4171b7dcd68b0cbe8ca10b0"
 dependencies = [
  "anyhow",
  "rand",
@@ -2814,8 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108da50438afee00396cb2c48419662ec2da8e771ec3a9f1a5b1ae794be98725"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2838,8 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b77dbf03fcfd0fa38bed6bc0cb9816fbb51d343db23346e56462c6c43c3e0083"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2850,8 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f82a9d27b7bad806115fa1dddaf043c1e168d8d4bc54fead73f98a472b4419"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -2863,8 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da425de42fdf84271ac1268d68ddd8d4f6bfc46b2804d754d8aee7fea46938cf"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2876,8 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f15ab0b561a2a882c95cd961f7fdaf4370cbf8d0590a726a9e6cf8c4ba8b4f5"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2888,8 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15656c4a89d7ab71d1883ad16e62148c82b30f335af8a25146ad3a6db4d5703"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2899,8 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4200e2f5f7a4312673123650a508148977e3d3695e49df84cc7a8420c428f5be"
 dependencies = [
  "indexmap",
  "rayon",
@@ -2914,8 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133fa30f6a0c37cb027361b7630216f501bee08fd7a616b5a431afebaa52f798"
 dependencies = [
  "bytes",
  "serde_json",
@@ -2927,8 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721fe467857f3f85aed85958a72fd3ddf333c1aa60bc8fca2c0770e1915682c6"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -2936,8 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df3fdd09d494e649609f066155792e81ce57c218af0d250c3af963e878bdf2e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2956,8 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75d413a7b9eeecd59bfbfe088fa9177cdc0aea2004e66be4acd7d66314d3af91"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2978,8 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83e392b4439236341c4a376246fa4cf5fb8ca368f69f09aceab04dfa515f7f8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2995,8 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f780376da38c5efbdcf137a05d96d3cf492b87d30f3d8a5c7eecf8c48273273b"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3020,8 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6560dfd95e2963b86baae31222609cb7e5fcc734dbfbf5993559c56a6c6fa51"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3042,8 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "800fd59b4942e3ad2d06982f8f531a80706ca0fdd72f92a1e255cf47747dac20"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3077,8 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-error"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052014a8b414daaf1c4ba5582e9ddf8505b2c28ea8c09affd7c4b75a3bbfdcda"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -3089,8 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e0212359bcc226fa24019d24be728e414b00d5846218129adcb8d4ff74ae78"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3115,8 +3169,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14344567bdaac5d8aaa82e1e1fc458e448ec53f59b62d7c6808bfe60e39981c0"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -3136,8 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71052ce457f0ec7fefae8d3fb07b21a0cc3007c0956f6cd2a3b247113c393dc3"
 dependencies = [
  "bincode",
  "serde_json",
@@ -3149,8 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1c9ddbc365e6575e3991bf191d8c0c42d9e55ba3963e7819ef047d77462e25"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3172,8 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a757dd7c952d69e6385cd0621c5c8ee7d4ab874f3ddc34b62a8d6bbfc56ae9ce"
 dependencies = [
  "proc-macro2",
  "quote 1.0.46",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aleo"
 authors = ["Konstantin Pandl", "Mike Turner", "Roman Proskuryakov"]
-version = "0.2.2"
+version = "0.3.1"
 description = "A Python sdk for zero-knowledge cryptography based on Aleo"
 edition = "2021"
 license = "GPL-3.0-or-later"
@@ -29,7 +29,7 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 
-snarkvm = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "v4.8.0", default-features = false, features = [
+snarkvm = { version = "4.8.1", default-features = false, features = [
     "console", "circuit", "synthesizer", "ledger", "utilities", "algorithms", "parameters",
 ] }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -29,7 +29,7 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 
-snarkvm = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "v4.8.1", default-features = false, features = [
+snarkvm = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "v4.8.0", default-features = false, features = [
     "console", "circuit", "synthesizer", "ledger", "utilities", "algorithms", "parameters",
 ] }
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "aleo-sdk"
 description = "Python SDK for building zero-knowledge apps and DeFi on the Aleo network"
-version = "0.2.2"
+version = "0.3.1"
 readme = "Readme.md"
 license = {file = "LICENSE.md"}
 authors = [

--- a/shield-swap-sdk/pyproject.toml
+++ b/shield-swap-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shield-swap-sdk"
-version = "0.2.2"
+version = "0.3.1"
 description = "Python SDK for the shield swap AMM Dex on Aleo"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
**REHEARSAL PR** — produced by a dry-run of the /upgrade-snarkvm automation (pin was staged back to v4.8.0 first). Review the shape, then close without merging.

## Changeset (v4.8.0 → v4.8.1)

- `ConsensusVersion::V17` introduced: anchor time reverts to 25s; mainnet heights set for V16 (19,860,000) and V17 (19,860,001); test-heights table extended to V17→20.
- `Network::ANCHOR_TIMES` const grew from 2 to 3 entries (type change; SDK does not reference it directly).
- History indexing performance fix in ledger/store internals; cargo-audit dep bump.

**Adaptation needed: none** — `sdk/src/programs/process.rs` already targets `ConsensusVersion::V17` (the code was adapted when v4.8.1 originally landed; this rehearsal only rolled back the pin).

## Dependency form

- `sdk/Cargo.toml`: switched to crates.io form (`snarkvm = { version = "4.8.1", ... }`) — 4.8.1 is published on crates.io. Features preserved verbatim.
- `sdk-abi/Cargo.toml`: leo HEAD (`60d258d`) now pins snarkvm via crates.io `version = "4.8.1"`, so sdk-abi mirrors that line exactly and bumps all leo revs to `60d258d` (type-coupling with leo-disassembler preserved).

## Validation

- `cargo fmt --check`, `cargo clippy` (mainnet, `-D warnings`), `cargo check` (testnet): clean
- Both-network wheel build + merge: OK
- pytest fast suite: **874 passed**
- Proving suite: **4 passed, 1 skipped**; testnet surface: **6 passed**
- aleo-contract-abi-generator suite: **8 passed**; abi hook: **3 passed**
- Build-graph isolation canary (`dev_skip_checks` not in sdk/Cargo.lock): clean

## Version bumps (one patch above live PyPI, 0.3.0)

- aleo-sdk 0.3.1, aleo-contract-abi-generator 0.3.1, shield-swap-sdk 0.3.1